### PR TITLE
Implement periodic updates alongside state change updates (--interval)

### DIFF
--- a/anime_rpc/__main__.py
+++ b/anime_rpc/__main__.py
@@ -58,7 +58,7 @@ async def consumer_loop(
     queue: asyncio.Queue[State],
     session: aiohttp.ClientSession,
 ) -> None:
-    presence = Presence(event)
+    presence = Presence()
     flags: UpdateFlags | None = None
 
     last_state: State = {}

--- a/anime_rpc/__main__.py
+++ b/anime_rpc/__main__.py
@@ -93,9 +93,9 @@ async def consumer_loop(
             )
             last_log_time = t1
 
-        # store this to a variable outside of the while loop
-        # so it only gets consumed when the origin check passes
-        # otherwise inactive pollers will consume this.
+        # store this in a variable outside of the while loop
+        # so it's only consumed when the origin check passes
+        # otherwise inactive pollers could consume this prematurely.
         if periodic_updates and periodic_update_in <= 0:
             _LOGGER.debug("Interval reached, resetting the clock...")
             t0 = perf_counter()

--- a/anime_rpc/cli.py
+++ b/anime_rpc/cli.py
@@ -13,12 +13,20 @@ class CLIArgs(argparse.Namespace):
     enable_webserver: bool
     pollers: list[type[BasePoller]]
     fetch_episode_titles: bool
+    interval: int
 
 
 _parser = argparse.ArgumentParser(
     "anime_rpc",
     description="Discord anime integration (rich presence)",
     formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=40),
+)
+_parser.add_argument(
+    "-v",
+    "--version",
+    action="version",
+    version=f"%(prog)s {__version__}",
+    help="show program's version number and exit",
 )
 _parser.add_argument(
     "--clear-on-pause",
@@ -52,11 +60,15 @@ _parser.add_argument(
     default=False,
 )
 _parser.add_argument(
-    "-v",
-    "--version",
-    action="version",
-    version=f"%(prog)s {__version__}",
-    help="show program's version number and exit",
+    "-i",
+    "--interval",
+    type=int,
+    help="specify the interval in seconds for periodic updates. "
+    "Defaults to 0, meaning updates occur only on play/stop events. "
+    "Setting an interval ensures periodic updates in addition to play/stop events, "
+    "useful if you want to always override Spotify activity "
+    "if both are running at the same time",
+    default=0,
 )
 CLI_ARGS, _unknown_args = _parser.parse_known_args(namespace=CLIArgs)
 
@@ -72,6 +84,7 @@ def print_cli_args() -> None:
         (CLI_ARGS.enable_webserver and "enabled") or "disabled",
     )
     _LOGGER.info("Fetch missing episode titles: %s", CLI_ARGS.fetch_episode_titles)
+    _LOGGER.info("Update interval: %ds", CLI_ARGS.interval)
 
     if _unknown_args:
         _LOGGER.warning("Unknown arguments: %s", shlex.join(_unknown_args))

--- a/anime_rpc/presence.py
+++ b/anime_rpc/presence.py
@@ -11,6 +11,7 @@ from pypresence import (  # type: ignore[reportMissingTypeStubs]
     ActivityType,
     AioPresence,
     DiscordError,
+    DiscordNotFound,
     PipeClosed,
     ResponseTimeout,
 )
@@ -114,6 +115,7 @@ class Presence:
             ResponseTimeout,
             struct.error,
             DiscordError,
+            DiscordNotFound,
         ):
             if not self._reconnecting:
                 _LOGGER.error(  # noqa: TRY400

--- a/anime_rpc/presence.py
+++ b/anime_rpc/presence.py
@@ -5,7 +5,7 @@ import logging
 import struct
 import time
 from enum import Flag, auto
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 from pypresence import (  # type: ignore[reportMissingTypeStubs]
     ActivityType,
@@ -25,9 +25,6 @@ from anime_rpc.states import (
     WatchingState,
     compare_states,
 )
-
-if TYPE_CHECKING:
-    import asyncio
 
 ORIGIN2SERVICE = {
     "mpc": "MPC-HC",
@@ -74,10 +71,9 @@ class UpdateFlags(Flag):
 
 
 class Presence:
-    def __init__(self, event: asyncio.Event) -> None:
+    def __init__(self) -> None:
         self._rpc: AioPresence | None = None
         self._last_application_id: int | None = None
-        self.event = event
         self._reconnecting = False
         self._last_kwargs: dict[str, Any] = {}
 

--- a/anime_rpc/presence.py
+++ b/anime_rpc/presence.py
@@ -77,7 +77,7 @@ class Presence:
         self._rpc: AioPresence | None = None
         self._last_application_id: int | None = None
         self.event = event
-        self._disconnected = False
+        self._reconnecting = False
         self._last_kwargs: dict[str, Any] = {}
 
     async def _ensure_application_id(self, application_id: int) -> None:
@@ -115,7 +115,7 @@ class Presence:
             struct.error,
             DiscordError,
         ):
-            if not self._disconnected:
+            if not self._reconnecting:
                 _LOGGER.error(  # noqa: TRY400
                     "Failed to connect to Discord. Is Discord running?",
                 )
@@ -132,10 +132,10 @@ class Presence:
                         CLI_ARGS.interval,
                     )
             self._rpc = None
-            self._disconnected = True
+            self._reconnecting = True
             return False
 
-        self._disconnected = False
+        self._reconnecting = False
         return True
 
     async def _clear(self, last_state: State) -> State:


### PR DESCRIPTION
- Periodic updates will give your Anime rich presence priority over Spotify, as now you can set it to update more frequently than Spotify via the `--interval` option.
- The rich presence will still update immediately if you pause/play the media even if you use `--interval`.
- This PR also simplifies reconnection mechanism. Previously, the client would attempt to reconnect with backoff intervals in multiples of 5s, capped at 30s. Now:
  - it reconnects at a fixed interval, set via the `--interval` option;
  - otherwise, it only reconnects on state changes, so you have to trigger it manually by playing/pausing to reconnect after reopening your Discord client.